### PR TITLE
a pair of documentation improvements

### DIFF
--- a/04-deploying-cluster.md
+++ b/04-deploying-cluster.md
@@ -344,8 +344,8 @@ FATAL failed to initialize the cluster: Cluster operator console is reporting a 
 2. Kill the CoreDNS pods (they'll be automatically respawned, but we've seen DNS errors cause deployment failures) in the `openshift-kni-infra` namespace:
 
    ~~~bash
-   [lab-user@provision scripts]$ for i in $(oc get pods -A | awk '/coredns/ {print $2;}'); \
-       do oc delete pod $i -n openshift-kni-infra; done
+   [lab-user@provision scripts]$ for i in $(oc --kubeconfig $HOME/scripts/ocp/auth/kubeconfig get pods -A | awk '/coredns/ {print $2;}'); \
+       do oc --kubeconfig $HOME/scripts/ocp/auth/kubeconfig delete pod $i -n openshift-kni-infra; done
    
    pod "coredns-master-0.xcs2v.dynamic.opentlc.com" deleted
    pod "coredns-master-1.xcs2v.dynamic.opentlc.com" deleted

--- a/09-workloads.md
+++ b/09-workloads.md
@@ -374,7 +374,7 @@ Now we can go ahead and create the virtual machine:
 
 ~~~bash
 [lab-user@provision scripts]$ oc create -f ~/virtualmachine-fedora.yaml 
-virtualmachine.kubevirt.io/cirros created
+virtualmachine.kubevirt.io/fedora created
 ~~~
 
 If we run a oc get pods for the default namespace we will see an importer container.  Once it is running we can watch the logs:


### PR DESCRIPTION
Hello and Thank you for putting this guide together! 
While going through I have hit the following two things, described in commits, that I believe can be fixed to improve experience further. One is missing `--kubeconfig` parameter to manage to delete coredns containers when troubleshooting failed deployment on first try, second is just cosmetic output improvement.

Ondrej